### PR TITLE
Revert "phymode HT20 -> HT40"

### DIFF
--- a/main/app_init.c
+++ b/main/app_init.c
@@ -39,7 +39,7 @@ void now_init() {
   ESP_ERROR_CHECK(esp_now_add_peer(&peer));
 
   esp_now_rate_config_t rate_config = {
-      .phymode = WIFI_PHY_MODE_HT40,
+      .phymode = WIFI_PHY_MODE_HT20,
       .rate = WIFI_PHY_RATE_MCS0_SGI,
   };
   const uint8_t peer_addr[] = BROADCAST_ADDR;


### PR DESCRIPTION
Reverts nipunchamikara/csi-data-collection-firmware#2

<img width="385" alt="image" src="https://github.com/user-attachments/assets/6fee4907-3544-4084-8636-a8464feef06f" />

Signal mode should be changed to 20HT to limit CSI size to 256 bytes.
This is to mitigate the limited payload size of ESP-NOW.
ESP32 only uses non STBC.